### PR TITLE
update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Connection parameters:
 ![connection](./public/readme/connection_configuration.png "DB Connection")
 
 The username and password are taken from [docker-compose.yml](./docker/docker-compose.yml)
-under `MYSQL_USER` and `MYSQL_PASSWORD`. 
+under `MYSQL_USER` and `MYSQL_PASSWORD`. Default username for MariaDb is  `root`
 The URL is standard MySql jdbc URL `jdbc:mariadb://localhost:3306/portal` and connect to database created 
 on start with name provided as `MYSQL_DATABASE`. For more [Docker Hub MariaDB](https://hub.docker.com/_/mariadb)
 under **Environment Variables**


### PR DESCRIPTION
add missing information about default DB user that is implicitly created by DB and not appear in docker-compose file